### PR TITLE
AND-44: Make patchDocument(), patchFolder() and patchAnnotation() return...

### DIFF
--- a/library/src/androidTest/java/com/mendeley/integration/AnnotationsNetworkBlockingTest.java
+++ b/library/src/androidTest/java/com/mendeley/integration/AnnotationsNetworkBlockingTest.java
@@ -107,31 +107,31 @@ public class AnnotationsNetworkBlockingTest extends AndroidTestCase {
         assertEquals("Sticky", annotation.text);
 
         Annotation modified = new Annotation.Builder(annotation).setText("Tacky").build();
-        sdk.patchAnnotation(id, modified);
+        Annotation patched = sdk.patchAnnotation(id, modified);
+        assertEquals(patched.id, id);
+        assertEquals(patched.text, "Tacky");
 
         modified = sdk.getAnnotation(id);
         assertEquals("Tacky", modified.text);
 
         modified = new Annotation.Builder(annotation).setText("Sticky").build();
-        sdk.patchAnnotation(id, modified);
+        patched = sdk.patchAnnotation(id, modified);
+        assertEquals(patched.id, id);
+        assertEquals(patched.text, "Sticky");
     }
 
     private void ensureCorrectAnnotationsExist() throws MendeleyException {
         AnnotationList annotationList = sdk.getAnnotations();
         String firstDocumentId = getFirstDocumentId();
 
-        // Delete any incorrect annotations:
+        // Delete existing annotations:
         for (Annotation annotation: annotationList.annotations) {
-            if (!isInFixture(annotation)) {
-                sdk.deleteAnnotation(annotation.id);
-            }
+            sdk.deleteAnnotation(annotation.id);
         }
 
-        // Post any missing annotations:
+        // Post clean annotations:
         for (Annotation templateAnnotation : ANNOTATIONS) {
-            if (!wasReceived(templateAnnotation, annotationList)) {
-                sdk.postAnnotation(attachToDocument(templateAnnotation, firstDocumentId));
-            }
+            sdk.postAnnotation(attachToDocument(templateAnnotation, firstDocumentId));
         }
     }
 

--- a/library/src/androidTest/java/com/mendeley/integration/DocumentNetworkBlockingTest.java
+++ b/library/src/androidTest/java/com/mendeley/integration/DocumentNetworkBlockingTest.java
@@ -84,16 +84,20 @@ public class DocumentNetworkBlockingTest extends AndroidTestCase {
 
         Document doc = new Document.Builder(docList.documents.get(0)).setYear(1066).build();
 
-        patchDocument(doc);
-        Document docRcvd = sdk.getDocument(doc.id, null);
+        Document patchedDoc = patchDocument(doc);
+        assertEquals("incorrect title", patchedDoc.title, doc.title);
+        assertEquals("incorrect year", patchedDoc.year.intValue(), 1066);
 
+        Document docRcvd = sdk.getDocument(doc.id, null);
         assertEquals("incorrect year", docRcvd.year.intValue(), 1066);
 
         doc = new Document.Builder(docList.documents.get(0)).setYear(2003).build();
 
-        patchDocument(doc);
-        docRcvd = getDocumentById(doc.id);
+        patchedDoc = patchDocument(doc);
+        assertEquals("incorrect title", patchedDoc.title, doc.title);
+        assertEquals("incorrect year", patchedDoc.year.intValue(), 2003);
 
+        docRcvd = getDocumentById(doc.id);
         assertEquals("incorrect year", docRcvd.year.intValue(), 2003);
     }
 
@@ -167,8 +171,8 @@ public class DocumentNetworkBlockingTest extends AndroidTestCase {
         return sdk.getDocuments(params);
     }
 
-    private void patchDocument(Document doc) throws MendeleyException {
-        sdk.patchDocument(doc.id, null, doc);
+    private Document patchDocument(Document doc) throws MendeleyException {
+        return sdk.patchDocument(doc.id, null, doc);
     }
 
     private Document getDocumentById(String id) throws MendeleyException {

--- a/library/src/androidTest/java/com/mendeley/integration/DocumentNetworkProviderTest.java
+++ b/library/src/androidTest/java/com/mendeley/integration/DocumentNetworkProviderTest.java
@@ -51,6 +51,7 @@ public class DocumentNetworkProviderTest extends BaseNetworkProviderTest {
     private List<Document> documentsRcvd;
     private Page pageRcvd;
     private Document documentRcvd;
+    private Document patchedDocumentRcvd;
     private Document postedDocumentRcvd;
     private Map<String, String> typesRcvd;
     private List<DocumentId> documentIdsRcvd;
@@ -112,7 +113,8 @@ public class DocumentNetworkProviderTest extends BaseNetworkProviderTest {
         };
         patchDocumentCallback = new PatchDocumentCallback() {
             @Override
-            public void onDocumentPatched(String documentId) {
+            public void onDocumentPatched(Document document) {
+                setPatched(document);
                 reportSuccess();
             }
 
@@ -185,15 +187,19 @@ public class DocumentNetworkProviderTest extends BaseNetworkProviderTest {
         Document doc = new Document.Builder(documentsRcvd.get(0)).setYear(1066).build();
 
         patchDocument(doc);
-        getDocumentById(doc.id);
+        assertEquals("incorrect title", patchedDocumentRcvd.title, doc.title);
+        assertEquals("incorrect year", patchedDocumentRcvd.year.intValue(), 1066);
 
+        getDocumentById(doc.id);
         assertEquals("incorrect year", documentRcvd.year.intValue(), 1066);
 
         doc = new Document.Builder(documentsRcvd.get(0)).setYear(2003).build();
 
         patchDocument(doc);
-        getDocumentById(doc.id);
+        assertEquals("incorrect title", patchedDocumentRcvd.title, doc.title);
+        assertEquals("incorrect year", patchedDocumentRcvd.year.intValue(), 2003);
 
+        getDocumentById(doc.id);
         assertEquals("incorrect year", documentsRcvd.get(0).year.intValue(), 2003);
     }
 
@@ -255,6 +261,10 @@ public class DocumentNetworkProviderTest extends BaseNetworkProviderTest {
 
     private void setTypes(Map<String, String> types) {
         typesRcvd = types;
+    }
+
+    private void setPatched(Document document) {
+        patchedDocumentRcvd = document;
     }
 
     private void setDeletedDocuments(List<DocumentId> documentIds, Page page) {

--- a/library/src/androidTest/java/com/mendeley/integration/FolderNetworkBlockingTest.java
+++ b/library/src/androidTest/java/com/mendeley/integration/FolderNetworkBlockingTest.java
@@ -62,15 +62,17 @@ public class FolderNetworkBlockingTest extends AndroidTestCase {
         Folder folder = new Folder.Builder(folderList.folders.get(0))
                 .setName("Zero gravity croquet").build();
 
-        sdk.patchFolder(folder.id, folder);
-        folderList = getFolders();
+        Folder patched = sdk.patchFolder(folder.id, folder);
+        assertEquals("folder name incorrect", patched.name, "Zero gravity croquet");
 
+        folderList = getFolders();
         assertEquals("folder name incorrect", "Zero gravity croquet", folderList.folders.get(2).name);
 
         folder = new Folder.Builder(folderList.folders.get(2))
                 .setName(originalName).build();
 
-        sdk.patchFolder(folder.id, folder);
+        patched = sdk.patchFolder(folder.id, folder);
+        assertEquals("folder name incorrect", patched.name, "Chocolate");
     }
 
     private void ensureCorrectFoldersExist() throws MendeleyException {

--- a/library/src/androidTest/java/com/mendeley/integration/FolderNetworkProviderTest.java
+++ b/library/src/androidTest/java/com/mendeley/integration/FolderNetworkProviderTest.java
@@ -32,6 +32,7 @@ public class FolderNetworkProviderTest extends BaseNetworkProviderTest {
 
     private List<Folder> foldersRcvd;
     private Folder postedFolderRcvd;
+    private Folder patchedFolderRcvd;
 
     private GetFoldersCallback getFoldersCallback;
     private PostFolderCallback postFolderCallback;
@@ -77,7 +78,8 @@ public class FolderNetworkProviderTest extends BaseNetworkProviderTest {
         };
         patchFolderCallback = new PatchFolderCallback() {
             @Override
-            public void onFolderPatched(String folderId) {
+            public void onFolderPatched(Folder folder) {
+                setPatchedFolder(folder);
                 reportSuccess();
             }
 
@@ -121,14 +123,16 @@ public class FolderNetworkProviderTest extends BaseNetworkProviderTest {
                 .setName("Zero gravity croquet").build();
 
         patchFolder(folder);
-        getFolders();
+        assertEquals("folder name incorrect", patchedFolderRcvd.name, "Zero gravity croquet");
 
+        getFolders();
         assertEquals("folder name incorrect", "Zero gravity croquet", foldersRcvd.get(2).name);
 
         folder = new Folder.Builder(foldersRcvd.get(2))
                 .setName(originalName).build();
 
         patchFolder(folder);
+        assertEquals("folder name incorrect", patchedFolderRcvd.name, "Chocolate");
     }
 
     private void patchFolder(Folder folder) {
@@ -176,6 +180,10 @@ public class FolderNetworkProviderTest extends BaseNetworkProviderTest {
 
     private void setPostedFolder(Folder folder) {
         this.postedFolderRcvd = folder;
+    }
+
+    private void setPatchedFolder(Folder folder) {
+        this.patchedFolderRcvd = folder;
     }
 
     private void setFolders(List<Folder> folders) {

--- a/library/src/main/java/com/mendeley/api/BlockingSdk.java
+++ b/library/src/main/java/com/mendeley/api/BlockingSdk.java
@@ -82,7 +82,7 @@ public interface BlockingSdk {
      * @param document a document object containing the fields to be updated.
      *                 Missing fields are left unchanged (not cleared).
      */
-    void patchDocument(String documentId, Date date, Document document) throws MendeleyException;
+    Document patchDocument(String documentId, Date date, Document document) throws MendeleyException;
 
     /**
      * Move an existing document into the user's trash collection.
@@ -163,7 +163,7 @@ public interface BlockingSdk {
      * @param folderId the id of the folder to modify.
      * @param folder metadata object that provides the new name and parentId.
      */
-    void patchFolder(String folderId, Folder folder) throws MendeleyException;
+    Folder patchFolder(String folderId, Folder folder) throws MendeleyException;
 
     /**
      * Return a list of IDs of the documents stored in a particular folder.
@@ -302,7 +302,7 @@ public interface BlockingSdk {
 
     Annotation postAnnotation(Annotation annotation) throws MendeleyException;
 
-    void patchAnnotation(String annotationId, Annotation annotation) throws MendeleyException;
+    Annotation patchAnnotation(String annotationId, Annotation annotation) throws MendeleyException;
 
     void deleteAnnotation(String annotationId) throws MendeleyException;
 

--- a/library/src/main/java/com/mendeley/api/MendeleySdk.java
+++ b/library/src/main/java/com/mendeley/api/MendeleySdk.java
@@ -149,7 +149,7 @@ public interface MendeleySdk {
      * @param document a document object containing the fields to be updated.
      *                 Missing fields are left unchanged (not cleared).
      */
-    void patchDocument(String documentId, Date date, Document document, PatchDocumentCallback callback);
+    RequestHandle patchDocument(String documentId, Date date, Document document, PatchDocumentCallback callback);
 
     /**
      * Move an existing document into the user's trash collection.
@@ -296,7 +296,7 @@ public interface MendeleySdk {
      * @param folderId the id of the folder to modify.
      * @param folder metadata object that provides the new name and parentId.
      */
-    void patchFolder(String folderId, Folder folder, PatchFolderCallback callback);
+    RequestHandle patchFolder(String folderId, Folder folder, PatchFolderCallback callback);
 
     /**
      * Return a list of IDs of the documents stored in a particular folder.

--- a/library/src/main/java/com/mendeley/api/callbacks/document/PatchDocumentCallback.java
+++ b/library/src/main/java/com/mendeley/api/callbacks/document/PatchDocumentCallback.java
@@ -1,8 +1,9 @@
 package com.mendeley.api.callbacks.document;
 
 import com.mendeley.api.exceptions.MendeleyException;
+import com.mendeley.api.model.Document;
 
 public interface PatchDocumentCallback {
-    public void onDocumentPatched(String documentId);
+    public void onDocumentPatched(Document document);
     public void onDocumentNotPatched(MendeleyException mendeleyException);
 }

--- a/library/src/main/java/com/mendeley/api/callbacks/folder/PatchFolderCallback.java
+++ b/library/src/main/java/com/mendeley/api/callbacks/folder/PatchFolderCallback.java
@@ -1,8 +1,9 @@
 package com.mendeley.api.callbacks.folder;
 
 import com.mendeley.api.exceptions.MendeleyException;
+import com.mendeley.api.model.Folder;
 
 public interface PatchFolderCallback {
-    public void onFolderPatched(String folderId);
+    public void onFolderPatched(Folder folder);
     public void onFolderNotPatched(MendeleyException mendeleyException);
 }

--- a/library/src/main/java/com/mendeley/api/impl/AsyncMendeleySdk.java
+++ b/library/src/main/java/com/mendeley/api/impl/AsyncMendeleySdk.java
@@ -130,14 +130,12 @@ public abstract class AsyncMendeleySdk extends BaseMendeleySdk implements Mendel
         });
     }
 
-
     @Override
-    public void patchDocument(final String documentId, final Date date, final Document document, final PatchDocumentCallback callback) {
-        run(new Command() {
+    public RequestHandle patchDocument(final String documentId, final Date date, final Document document, final PatchDocumentCallback callback) {
+        return run(new Command() {
             @Override
             public RequestHandle exec() {
-                documentNetworkProvider.doPatchDocument(documentId, date, document, callback);
-                return null;
+                return documentNetworkProvider.doPatchDocument(documentId, date, document, callback);
             }
         });
     }
@@ -341,12 +339,11 @@ public abstract class AsyncMendeleySdk extends BaseMendeleySdk implements Mendel
     }
 
     @Override
-    public void patchFolder(final String folderId, final Folder folder, final PatchFolderCallback callback) {
-        run(new Command() {
+    public RequestHandle patchFolder(final String folderId, final Folder folder, final PatchFolderCallback callback) {
+        return run(new Command() {
             @Override
             public RequestHandle exec() {
-                folderNetworkProvider.doPatchFolder(folderId, folder, callback);
-                return null;
+                return folderNetworkProvider.doPatchFolder(folderId, folder, callback);
             }
         });
     }

--- a/library/src/main/java/com/mendeley/api/impl/BaseMendeleySdk.java
+++ b/library/src/main/java/com/mendeley/api/impl/BaseMendeleySdk.java
@@ -204,11 +204,11 @@ public abstract class BaseMendeleySdk implements BlockingSdk, Environment {
     }
 
     @Override
-    public void patchDocument(String documentId, Date date, Document document) throws MendeleyException {
+    public Document patchDocument(String documentId, Date date, Document document) throws MendeleyException {
         try {
             String json = JsonParser.jsonFromDocument(document);
-            Procedure proc = new PatchDocumentProcedure(documentId, json, date, authenticationManager);
-            proc.checkedRun();
+            Procedure<Document> proc = new PatchDocumentProcedure(documentId, json, date, authenticationManager);
+            return proc.checkedRun();
         } catch (JSONException e) {
             throw new JsonParsingException(e.getMessage());
         }
@@ -279,11 +279,11 @@ public abstract class BaseMendeleySdk implements BlockingSdk, Environment {
     }
 
     @Override
-    public void patchAnnotation(String annotationId, Annotation annotation) throws MendeleyException {
+    public Annotation patchAnnotation(String annotationId, Annotation annotation) throws MendeleyException {
         try {
             String json = JsonParser.jsonFromAnnotation(annotation);
-            Procedure proc = new PatchAnnotationProcedure(annotationId, json, authenticationManager);
-            proc.checkedRun();
+            Procedure<Annotation> proc = new PatchAnnotationProcedure(annotationId, json, authenticationManager);
+            return proc.checkedRun();
         } catch (JSONException e) {
             throw new JsonParsingException("Error parsing annotation", e);
         }
@@ -366,13 +366,13 @@ public abstract class BaseMendeleySdk implements BlockingSdk, Environment {
     }
 
     @Override
-    public void patchFolder(String folderId, Folder folder) throws MendeleyException {
+    public Folder patchFolder(String folderId, Folder folder) throws MendeleyException {
         String folderString = null;
         try {
             String url = FolderNetworkProvider.getPatchFolderUrl(folderId);
             folderString  = JsonParser.jsonFromFolder(folder);
-            Procedure proc = new PatchFolderProcedure(url, folderString, authenticationManager);
-            proc.checkedRun();
+            Procedure<Folder> proc = new PatchFolderProcedure(url, folderString, authenticationManager);
+            return proc.checkedRun();
         } catch (JSONException e) {
             throw new JsonParsingException(e.getMessage());
         }

--- a/library/src/main/java/com/mendeley/api/network/provider/AnnotationsNetworkProvider.java
+++ b/library/src/main/java/com/mendeley/api/network/provider/AnnotationsNetworkProvider.java
@@ -118,13 +118,18 @@ public class AnnotationsNetworkProvider {
         }
     }
 
-    public static class PatchAnnotationProcedure extends PatchNetworkProcedure {
+    public static class PatchAnnotationProcedure extends PatchNetworkProcedure<Annotation> {
         public PatchAnnotationProcedure(String annotationId, String json, AuthenticationManager authenticationManager) {
             super(getUrl(annotationId), CONTENT_TYPE, json, null, authenticationManager);
         }
 
         private static String getUrl(String annotationId) {
             return ANNOTATIONS_BASE_URL + "/" + annotationId;
+        }
+
+        @Override
+        protected Annotation processJsonString(String jsonString) throws JSONException {
+            return JsonParser.parseAnnotation(jsonString);
         }
     }
 }

--- a/library/src/main/java/com/mendeley/api/network/task/PatchNetworkTask.java
+++ b/library/src/main/java/com/mendeley/api/network/task/PatchNetworkTask.java
@@ -5,14 +5,17 @@ import com.mendeley.api.exceptions.JsonParsingException;
 import com.mendeley.api.exceptions.MendeleyException;
 import com.mendeley.api.network.NetworkUtils;
 
+import org.apache.http.HttpEntity;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.HttpClient;
 import org.apache.http.entity.StringEntity;
 import org.apache.http.impl.client.DefaultHttpClient;
+import org.json.JSONException;
 
 import java.io.IOException;
 
 import static com.mendeley.api.network.NetworkUtils.getHttpPatch;
+import static com.mendeley.api.network.NetworkUtils.getJsonString;
 
 public abstract class PatchNetworkTask extends NetworkTask {
     @Override
@@ -36,14 +39,22 @@ public abstract class PatchNetworkTask extends NetworkTask {
             if (responseCode != getExpectedResponse()) {
                 return new HttpResponseException(url, responseCode, NetworkUtils.getErrorMessage(response));
             } else {
+                HttpEntity responseEntity = response.getEntity();
+                is = responseEntity.getContent();
+                String responseString = getJsonString(is);
+                processJsonString(responseString);
                 return null;
             }
         } catch (IOException e) {
+            return new JsonParsingException(e.getMessage());
+        } catch (JSONException e) {
             return new JsonParsingException(e.getMessage());
         } finally {
             closeConnection();
         }
     }
+
+    protected abstract void processJsonString(String jsonString) throws JSONException;
 
     protected abstract String getDate();
 


### PR DESCRIPTION
AND-44: Make patchDocument(), patchFolder() and patchAnnotation() return the modified object.

Apply changes to sync and async calls (except Annotations which are sync-only at present).