### PR TITLE
Allow creating document builder with empty title and type

### DIFF
--- a/library/src/androidTest/java/com/mendeley/api/network/JsonParserTest.java
+++ b/library/src/androidTest/java/com/mendeley/api/network/JsonParserTest.java
@@ -63,8 +63,10 @@ public class JsonParserTest extends InstrumentationTestCase {
 	}
 
     public Document getTestDocument(ArrayList<Person> authorsList, ArrayList<Person> editorsList, ArrayList<String> keywords, ArrayList<String> tags, ArrayList<String> websites, HashMap<String, String> identifiers) {
-        Document.Builder testDocument = new Document.Builder("test-title", "book");
+        Document.Builder testDocument = new Document.Builder();
 
+        testDocument.setTitle("test-title");
+        testDocument.setType("book");
         testDocument.setAuthors(authorsList);
         testDocument.setEditors(editorsList);
         testDocument.setKeywords(keywords);

--- a/library/src/androidTest/java/com/mendeley/api/network/NetworkConnectionTest.java
+++ b/library/src/androidTest/java/com/mendeley/api/network/NetworkConnectionTest.java
@@ -42,7 +42,10 @@ public class NetworkConnectionTest extends AndroidTestCase {
 	
 
 	public static Document getTestDocument() {
-		return new Document.Builder("test_document_title", "book").setId("test_document_id").build();
+		return new Document.Builder()
+                .setTitle("test_document_title")
+                .setType("book")
+                .setId("test_document_id").build();
 	}
 
 	private void createConnections()

--- a/library/src/androidTest/java/com/mendeley/integration/DocumentNetworkBlockingTest.java
+++ b/library/src/androidTest/java/com/mendeley/integration/DocumentNetworkBlockingTest.java
@@ -22,16 +22,30 @@ import java.util.TimeZone;
 
 public class DocumentNetworkBlockingTest extends AndroidTestCase {
     private static final Document[] DOCUMENTS = {
-            new Document.Builder("How to avoid huge ships", "book")
+            new Document.Builder()
+                    .setTitle("How to avoid huge ships")
+                    .setType("book")
                     .setYear(1993).build(),
-            new Document.Builder("Cheese problems solved", "book")
-                    .setYear(2007).build(),
-            new Document.Builder("Across Europe by Kangaroo", "book")
-                    .setYear(2003).build(),
-            new Document.Builder("How to Be Pope: What to Do and Where to Go Once You're in the Vatican", "book")
-                    .setYear(2005).build(),
-            new Document.Builder("Be Bold with Bananas", "book")
-                    .setYear(1972).build()
+            new Document.Builder()
+                    .setYear(2007)
+                    .setTitle("Cheese problems solved")
+                    .setType("book")
+                    .build(),
+            new Document.Builder()
+                    .setYear(2003)
+                    .setTitle("Across Europe by Kangaroo")
+                    .setType("book")
+                    .build(),
+            new Document.Builder()
+                    .setYear(2005)
+                    .setTitle("How to Be Pope: What to Do and Where to Go Once You're in the Vatican")
+                    .setType("book")
+                    .build(),
+            new Document.Builder()
+                    .setYear(1972)
+                    .setTitle("Be Bold with Bananas")
+                    .setType("book")
+                    .build()
     };
 
     private BlockingSdk sdk;
@@ -68,7 +82,10 @@ public class DocumentNetworkBlockingTest extends AndroidTestCase {
     }
 
     public void testPostAndDeleteDocument() throws MendeleyException {
-        Document doc = new Document.Builder("abc", "book").build();
+        Document doc = new Document.Builder()
+                .setTitle("abc")
+                .setType("book")
+                .build();
 
         Document rcvd = sdk.postDocument(doc);
 

--- a/library/src/androidTest/java/com/mendeley/integration/DocumentNetworkProviderTest.java
+++ b/library/src/androidTest/java/com/mendeley/integration/DocumentNetworkProviderTest.java
@@ -26,16 +26,31 @@ import java.util.TimeZone;
 
 public class DocumentNetworkProviderTest extends BaseNetworkProviderTest {
     private static final Document[] DOCUMENTS = {
-            new Document.Builder("How to avoid huge ships", "book")
-                    .setYear(1993).build(),
-            new Document.Builder("Cheese problems solved", "book")
-                    .setYear(2007).build(),
-            new Document.Builder("Across Europe by Kangaroo", "book")
-                    .setYear(2003).build(),
-            new Document.Builder("How to Be Pope: What to Do and Where to Go Once You're in the Vatican", "book")
-                    .setYear(2005).build(),
-            new Document.Builder("Be Bold with Bananas", "book")
-                    .setYear(1972).build()
+            new Document.Builder()
+                    .setTitle("How to avoid huge ships")
+                    .setType("book")
+                    .setYear(1993)
+                    .build(),
+            new Document.Builder()
+                    .setTitle("Cheese problems solved")
+                    .setType("book")
+                    .setYear(2007)
+                    .build(),
+            new Document.Builder()
+                    .setTitle("Across Europe by Kangaroo")
+                    .setType("book")
+                    .setYear(2003)
+                    .build(),
+            new Document.Builder()
+                    .setTitle("How to Be Pope: What to Do and Where to Go Once You're in the Vatican")
+                    .setType("book")
+                    .setYear(2005)
+                    .build(),
+            new Document.Builder()
+                    .setTitle("Be Bold with Bananas")
+                    .setType("book")
+                    .setYear(1972)
+                    .build()
     };
 
     private MendeleySdk sdk;
@@ -170,7 +185,10 @@ public class DocumentNetworkProviderTest extends BaseNetworkProviderTest {
     }
 
     public void testPostAndDeleteDocument() {
-        Document doc = new Document.Builder("abc", "book").build();
+        Document doc = new Document.Builder()
+                .setTitle("abc")
+                .setType("book")
+                .build();
 
         postDocument(doc);
 

--- a/library/src/main/java/com/mendeley/api/model/Document.java
+++ b/library/src/main/java/com/mendeley/api/model/Document.java
@@ -1,6 +1,5 @@
 package com.mendeley.api.model;
 
-import com.mendeley.api.util.Nullable;
 import com.mendeley.api.util.NullableList;
 import com.mendeley.api.util.NullableMap;
 
@@ -174,9 +173,7 @@ public class Document {
         private String clientData;
         private String uniqueId;
 		
-		public Builder(String title, String type) {
-            this.title = title;
-            this.type = type;
+		public Builder() {
         }
 		
 		public Builder(Document from) {
@@ -221,6 +218,11 @@ public class Document {
 
         public Builder setTitle(String title) {
             this.title = title;
+            return this;
+        }
+
+        public Builder setType(String type) {
+            this.type = type;
             return this;
         }
 
@@ -288,7 +290,7 @@ public class Document {
 			this.source = source;
 			return this;
 		}
-		
+
 		public Builder setRevision(String revision) {
 			this.revision = revision;
 			return this;
@@ -442,8 +444,8 @@ public class Document {
 		}
 	}
 
-    public static Builder getBuilder(String title, String type) {
-        return new Builder(title, type);
+    public static Builder getBuilder() {
+        return new Builder();
     }
 
     public String getAuthorsString() {

--- a/library/src/main/java/com/mendeley/api/network/JsonParser.java
+++ b/library/src/main/java/com/mendeley/api/network/JsonParser.java
@@ -756,13 +756,19 @@ public class JsonParser {
         }
 
         String type = documentObject.getString("type");
-		Document.Builder mendeleyDocument = new Document.Builder(title, type);
+		Document.Builder mendeleyDocument = new Document.Builder();
 
 		for (@SuppressWarnings("unchecked")
              Iterator<String> keysIter = documentObject.keys(); keysIter.hasNext(); ) {
 
 			String key = keysIter.next();
-            if (key.equals("last_modified")) {
+            if (key.equals("title")) {
+                mendeleyDocument.setTitle(documentObject.getString(key));
+
+            } else if (key.equals("type")) {
+                mendeleyDocument.setType(documentObject.getString(key));
+
+            } else if (key.equals("last_modified")) {
                 mendeleyDocument.setLastModified(documentObject.getString(key));
 
             } else if (key.equals("group_id")) {


### PR DESCRIPTION
We need to support creating a doc without title. Otherwise, the client will always override the title of the document in the server, even if the user did not edit this field.
Idem for type.