### PR TITLE
Fixes in Annotation#Builder and parser to make it compatible with implem...

### DIFF
--- a/library/src/androidTest/java/com/mendeley/integration/AnnotationsNetworkBlockingTest.java
+++ b/library/src/androidTest/java/com/mendeley/integration/AnnotationsNetworkBlockingTest.java
@@ -74,7 +74,7 @@ public class AnnotationsNetworkBlockingTest extends AndroidTestCase {
         assertEquals("annotation type incorrect",
                 Annotation.Type.STICKY_NOTE, annotationList.annotations.get(0).type);
         assertEquals("annotation color incorrect",
-                Color.CYAN, annotationList.annotations.get(1).color);
+                 Color.CYAN, (int) annotationList.annotations.get(1).color);
         assertEquals("annotation text incorrect",
                 "Doc note", annotationList.annotations.get(2).text);
     }

--- a/library/src/debug/assets/test_annotation_not_null_values.json
+++ b/library/src/debug/assets/test_annotation_not_null_values.json
@@ -1,0 +1,30 @@
+{
+    "id": "test-id",
+    "text": "test-text",
+    "type": "highlight",
+    "color": {
+      "r": 255,
+      "g": 0,
+      "b": 0
+    },
+    "profile_id": "test-profile-id",
+    "positions": [
+      {
+        "top_left": {
+          "x": 1,
+          "y": 2
+        },
+        "bottom_right": {
+          "x": 3,
+          "y": 4
+        },
+        "page": 5
+      }
+    ],
+    "created": "2014-02-20T16:53:25.000Z",
+    "last_modified": "2015-02-20T16:53:25.000Z",
+    "privacy_level": "private",
+    "filehash": "test-hash",
+    "document_id": "test-doc-id",
+    "previous_id": "test-prev-id"
+}

--- a/library/src/debug/assets/test_annotation_null_values.json
+++ b/library/src/debug/assets/test_annotation_null_values.json
@@ -1,0 +1,10 @@
+{
+    "id": "test-id",
+    "text": "test-text",
+    "profile_id": "test-profile-id",
+    "created": "2014-02-20T16:53:25.000Z",
+    "last_modified": "2015-02-20T16:53:25.000Z",
+    "filehash": "test-hash",
+    "document_id": "test-doc-id",
+    "previous_id": "test-prev-id"
+}

--- a/library/src/main/java/com/mendeley/api/model/Annotation.java
+++ b/library/src/main/java/com/mendeley/api/model/Annotation.java
@@ -1,8 +1,7 @@
 package com.mendeley.api.model;
 
-import android.graphics.Color;
+import com.mendeley.api.util.NullableList;
 
-import java.util.ArrayList;
 import java.util.List;
 
 public class Annotation {
@@ -44,10 +43,10 @@ public class Annotation {
     public final String id;
     public final Type type;
     public final String previousId;
-    public final int color;
+    public final Integer color;
     public final String text;
     public final String profileId;
-    public final List<Box> positions;
+    public final NullableList<Box> positions;
     public final String created;
     public final String lastModified;
     public final PrivacyLevel privacyLevel;
@@ -58,7 +57,7 @@ public class Annotation {
             String id,
             Type type,
             String previousId,
-            int color,
+            Integer color,
             String text,
             String profileId,
             List<Box> positions,
@@ -73,7 +72,7 @@ public class Annotation {
         this.color = color;
         this.text = text;
         this.profileId = profileId;
-        this.positions = positions;
+        this.positions = new NullableList<Box>(positions);
         this.created = created;
         this.lastModified = lastModified;
         this.privacyLevel = privacyLevel;
@@ -81,11 +80,49 @@ public class Annotation {
         this.documentId = documentId;
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        Annotation that = (Annotation) o;
+
+        if (color != null ? !color.equals(that.color) : that.color != null) return false;
+        if (documentId != null ? !documentId.equals(that.documentId) : that.documentId != null)
+            return false;
+        if (fileHash != null ? !fileHash.equals(that.fileHash) : that.fileHash != null)
+            return false;
+        if (id != null ? !id.equals(that.id) : that.id != null) return false;
+        if (positions != null ? !positions.equals(that.positions) : that.positions != null)
+            return false;
+        if (privacyLevel != that.privacyLevel) return false;
+        if (profileId != null ? !profileId.equals(that.profileId) : that.profileId != null)
+            return false;
+        if (text != null ? !text.equals(that.text) : that.text != null) return false;
+        if (type != that.type) return false;
+
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = id != null ? id.hashCode() : 0;
+        result = 31 * result + (type != null ? type.hashCode() : 0);
+        result = 31 * result + (color != null ? color.hashCode() : 0);
+        result = 31 * result + (text != null ? text.hashCode() : 0);
+        result = 31 * result + (profileId != null ? profileId.hashCode() : 0);
+        result = 31 * result + (positions != null ? positions.hashCode() : 0);
+        result = 31 * result + (privacyLevel != null ? privacyLevel.hashCode() : 0);
+        result = 31 * result + (fileHash != null ? fileHash.hashCode() : 0);
+        result = 31 * result + (documentId != null ? documentId.hashCode() : 0);
+        return result;
+    }
+
     public static class Builder {
         private String id;
         private Type type;
         private String previousId;
-        private int color;
+        private Integer color;
         private String text;
         private String profileId;
         private List<Box> positions;
@@ -96,10 +133,6 @@ public class Annotation {
         private String documentId;
 
         public Builder() {
-            // Reasonable defaults:
-            this.privacyLevel = PrivacyLevel.PRIVATE;
-            this.positions = new ArrayList<Box>();
-            this.color = Color.BLACK;
         }
 
         public Builder(Annotation from) {

--- a/library/src/main/java/com/mendeley/api/model/Box.java
+++ b/library/src/main/java/com/mendeley/api/model/Box.java
@@ -10,4 +10,27 @@ public class Box {
         this.bottomRight = bottomRight;
         this.page = page;
     }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        Box box = (Box) o;
+
+        if (bottomRight != null ? !bottomRight.equals(box.bottomRight) : box.bottomRight != null)
+            return false;
+        if (page != null ? !page.equals(box.page) : box.page != null) return false;
+        if (topLeft != null ? !topLeft.equals(box.topLeft) : box.topLeft != null) return false;
+
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = topLeft != null ? topLeft.hashCode() : 0;
+        result = 31 * result + (bottomRight != null ? bottomRight.hashCode() : 0);
+        result = 31 * result + (page != null ? page.hashCode() : 0);
+        return result;
+    }
 }

--- a/library/src/main/java/com/mendeley/api/model/Point.java
+++ b/library/src/main/java/com/mendeley/api/model/Point.java
@@ -8,4 +8,28 @@ public class Point {
         this.x = x;
         this.y = y;
     }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        Point point = (Point) o;
+
+        if (Double.compare(point.x, x) != 0) return false;
+        if (Double.compare(point.y, y) != 0) return false;
+
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        int result;
+        long temp;
+        temp = Double.doubleToLongBits(x);
+        result = (int) (temp ^ (temp >>> 32));
+        temp = Double.doubleToLongBits(y);
+        result = 31 * result + (int) (temp ^ (temp >>> 32));
+        return result;
+    }
 }

--- a/library/src/main/java/com/mendeley/api/network/JsonParser.java
+++ b/library/src/main/java/com/mendeley/api/network/JsonParser.java
@@ -42,24 +42,33 @@ public class JsonParser {
     private static final String TAG = JsonParser.class.getCanonicalName();
 
     public static String jsonFromAnnotation(Annotation annotation) throws JSONException {
-        JSONArray positions = new JSONArray();
-        for (int i = 0; i < annotation.positions.size(); i++) {
-            Box box = annotation.positions.get(i);
-            positions.put(i, serializeBox(box));
-        }
-
         JSONObject jAnnotation = new JSONObject();
 
         jAnnotation.put("id", annotation.id);
-        jAnnotation.put("type", annotation.type.name);
+        if (annotation.type != null) {
+            jAnnotation.put("type", annotation.type.name);
+        }
         jAnnotation.put("previous_id", annotation.previousId);
-        jAnnotation.put("color", serializeColor(annotation.color));
+        if (annotation.color != null) {
+            jAnnotation.put("color", serializeColor(annotation.color));
+        }
         jAnnotation.put("text", annotation.text);
         jAnnotation.put("profile_id", annotation.profileId);
-        jAnnotation.put("positions", positions);
+
+        if (!annotation.positions.isNull()) {
+            JSONArray positions = new JSONArray();
+            for (int i = 0; i < annotation.positions.size(); i++) {
+                Box box = annotation.positions.get(i);
+                positions.put(i, serializeBox(box));
+            }
+            jAnnotation.put("positions", positions);
+        }
+
         jAnnotation.put("created", annotation.created);
         jAnnotation.put("last_modified", annotation.lastModified);
-        jAnnotation.put("privacy_level", annotation.privacyLevel.name);
+        if (annotation.privacyLevel != null) {
+            jAnnotation.put("privacy_level", annotation.privacyLevel.name);
+        }
         jAnnotation.put("filehash", annotation.fileHash);
         jAnnotation.put("document_id", annotation.documentId);
 
@@ -750,104 +759,98 @@ public class JsonParser {
     public static Document parseDocument(String jsonString) throws JSONException {
         JSONObject documentObject = new JSONObject(jsonString);
 
-        String title = "";
-        if (documentObject.has("title")) {
-            title = documentObject.getString("title");
-        }
-
-        String type = documentObject.getString("type");
-		Document.Builder mendeleyDocument = new Document.Builder();
+		Document.Builder bld = new Document.Builder();
 
 		for (@SuppressWarnings("unchecked")
              Iterator<String> keysIter = documentObject.keys(); keysIter.hasNext(); ) {
 
 			String key = keysIter.next();
             if (key.equals("title")) {
-                mendeleyDocument.setTitle(documentObject.getString(key));
+                bld.setTitle(documentObject.getString(key));
 
             } else if (key.equals("type")) {
-                mendeleyDocument.setType(documentObject.getString(key));
+                bld.setType(documentObject.getString(key));
 
             } else if (key.equals("last_modified")) {
-                mendeleyDocument.setLastModified(documentObject.getString(key));
+                bld.setLastModified(documentObject.getString(key));
 
             } else if (key.equals("group_id")) {
-                mendeleyDocument.setGroupId(documentObject.getString(key));
+                bld.setGroupId(documentObject.getString(key));
 
             } else if (key.equals("profile_id")) {
-                mendeleyDocument.setProfileId(documentObject.getString(key));
+                bld.setProfileId(documentObject.getString(key));
 
             } else if (key.equals("read")) {
-                mendeleyDocument.setRead(documentObject.getBoolean(key));
+                bld.setRead(documentObject.getBoolean(key));
 
             } else if (key.equals("starred")) {
-                mendeleyDocument.setStarred(documentObject.getBoolean(key));
+                bld.setStarred(documentObject.getBoolean(key));
 
             } else if (key.equals("authored")) {
-                mendeleyDocument.setAuthored(documentObject.getBoolean(key));
+                bld.setAuthored(documentObject.getBoolean(key));
 
             } else if (key.equals("confirmed")) {
-                mendeleyDocument.setConfirmed(documentObject.getBoolean(key));
+                bld.setConfirmed(documentObject.getBoolean(key));
 
             } else if (key.equals("hidden")) {
-                mendeleyDocument.setHidden(documentObject.getBoolean(key));
+                bld.setHidden(documentObject.getBoolean(key));
 
             } else if (key.equals("id")) {
-                mendeleyDocument.setId(documentObject.getString(key));
+                bld.setId(documentObject.getString(key));
 
             } else if (key.equals("month")) {
-                mendeleyDocument.setMonth(documentObject.getInt(key));
+                bld.setMonth(documentObject.getInt(key));
 
             } else if (key.equals("year")) {
-                mendeleyDocument.setYear(documentObject.getInt(key));
+                bld.setYear(documentObject.getInt(key));
 
             } else if (key.equals("day")) {
-                mendeleyDocument.setDay(documentObject.getInt(key));
+                bld.setDay(documentObject.getInt(key));
 
             } else if (key.equals("source")) {
-                mendeleyDocument.setSource(documentObject.getString(key));
+                bld.setSource(documentObject.getString(key));
 
             } else if (key.equals("revision")) {
-                mendeleyDocument.setRevision(documentObject.getString(key));
+                bld.setRevision(documentObject.getString(key));
 
             } else if (key.equals("created")) {
-                mendeleyDocument.setCreated(documentObject.getString(key));
+                bld.setCreated(documentObject.getString(key));
 
             } else if (key.equals("abstract")) {
-                mendeleyDocument.setAbstractString(documentObject.getString(key));
+                bld.setAbstractString(documentObject.getString(key));
 
             } else if (key.equals("pages")) {
-                mendeleyDocument.setPages(documentObject.getString(key));
+                bld.setPages(documentObject.getString(key));
 
             } else if (key.equals("volume")) {
-                mendeleyDocument.setVolume(documentObject.getString(key));
+                bld.setVolume(documentObject.getString(key));
 
             } else if (key.equals("issue")) {
-                mendeleyDocument.setIssue(documentObject.getString(key));
+                bld.setIssue(documentObject.getString(key));
 
             } else if (key.equals("publisher")) {
-                mendeleyDocument.setPublisher(documentObject.getString(key));
+                bld.setPublisher(documentObject.getString(key));
 
             } else if (key.equals("city")) {
-                mendeleyDocument.setCity(documentObject.getString(key));
+                bld.setCity(documentObject.getString(key));
 
             } else if (key.equals("edition")) {
-                mendeleyDocument.setEdition(documentObject.getString(key));
+                bld.setEdition(documentObject.getString(key));
 
             } else if (key.equals("institution")) {
-                mendeleyDocument.setInstitution(documentObject.getString(key));
+                bld.setInstitution(documentObject.getString(key));
 
             } else if (key.equals("series")) {
-                mendeleyDocument.setSeries(documentObject.getString(key));
+                bld.setSeries(documentObject.getString(key));
 
             } else if (key.equals("chapter")) {
-                mendeleyDocument.setChapter(documentObject.getString(key));
+                bld.setChapter(documentObject.getString(key));
 
             } else if (key.equals("client_data")) {
-                mendeleyDocument.setClientData(documentObject.getString(key));
+                bld.setClientData(documentObject.getString(key));
 
             } else if (key.equals("unique_id")) {
-                mendeleyDocument.setUniqueId(documentObject.getString(key));
+                bld.setUniqueId(documentObject.getString(key));
 
             } else if (key.equals("authors")) {
                 final JSONArray authors = documentObject.getJSONArray(key);
@@ -860,7 +863,7 @@ public class JsonParser {
                     authorsList.add(author);
                 }
 
-                mendeleyDocument.setAuthors(authorsList);
+                bld.setAuthors(authorsList);
 
             } else if (key.equals("editors")) {
                 JSONArray editors = documentObject.getJSONArray(key);
@@ -873,7 +876,7 @@ public class JsonParser {
                     editorsList.add(editor);
                 }
 
-                mendeleyDocument.setEditors(editorsList);
+                bld.setEditors(editorsList);
 
             } else if (key.equals("identifiers")) {
                 JSONObject identifiersObject = documentObject.getJSONObject(key);
@@ -886,7 +889,7 @@ public class JsonParser {
                     identifiersMap.put(identifierKey, identifiersObject.getString(identifierKey));
                 }
 
-                mendeleyDocument.setIdentifiers(identifiersMap);
+                bld.setIdentifiers(identifiersMap);
 
             } else if (key.equals("tags")) {
                 JSONArray tags = documentObject.getJSONArray(key);
@@ -896,13 +899,13 @@ public class JsonParser {
                     tagsList.add(tags.getString(i));
                 }
 
-                mendeleyDocument.setTags(tagsList);
+                bld.setTags(tagsList);
 
             } else if (key.equals("accessed")) {
-                mendeleyDocument.setAccessed(documentObject.getString(key));
+                bld.setAccessed(documentObject.getString(key));
 
             } else if (key.equals("file_attached")) {
-                mendeleyDocument.setFileAttached(documentObject.getBoolean(key));
+                bld.setFileAttached(documentObject.getBoolean(key));
 
             } else if (key.equals("keywords")) {
                 JSONArray keywords = documentObject.getJSONArray(key);
@@ -912,7 +915,7 @@ public class JsonParser {
                     keywordsList.add(keywords.getString(i));
                 }
 
-                mendeleyDocument.setKeywords(keywordsList);
+                bld.setKeywords(keywordsList);
 
             } else if (key.equals("websites")) {
                 JSONArray websites = documentObject.getJSONArray(key);
@@ -921,12 +924,12 @@ public class JsonParser {
                 for (int i = 0; i < websites.length(); i++) {
                     websitesList.add(websites.getString(i));
                 }
-                mendeleyDocument.setWebsites(websitesList);
+                bld.setWebsites(websitesList);
 
             }
 		}
 
-		return mendeleyDocument.build();
+		return bld.build();
 	}
 	
 	/**


### PR DESCRIPTION
I've found the same issues when PATCHing annotations that with documents: to avoid the server updating not-modified fields we need to make sure the sent JSON includes only the modified field.
For this purpose I've made the following changes:

- Annotation.Builder cannot set defaults - other wise they will be taken and applied by the server when patching.
- If we use empty lists as lists of Annotation positions to implement the null object pattern, we need to provide a mean to check if those lists are really empty or just represents null (NullList).
(we cannot pass an empty list of Positions to the server, as it will update the Annotation accordingly)
- Parsing the Annotation needs to cope with null references.

- some tests
